### PR TITLE
fixed a/b buttons to match 3ds button location

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -41,8 +41,8 @@ QPoint touchScreenPosition;
 void sendFrame(void)
 {
     static const QGamepadManager::GamepadButton hidButtons[] = {
-        QGamepadManager::ButtonA,
         QGamepadManager::ButtonB,
+        QGamepadManager::ButtonA,
         QGamepadManager::ButtonSelect,
         QGamepadManager::ButtonStart,
         QGamepadManager::ButtonRight,


### PR DESCRIPTION
For Xbox and Playstation controllers the A/B (X/O) buttons are swapped compared to the 3DS. This makes it match the physical button layout/location, even though the letter on the button isn't the same.