### PR TITLE
Make the interface buttons always override gamepad buttons...

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -62,9 +62,9 @@ void sendFrame(void)
     };
 
     static const QGamepadManager::GamepadButton speButtons[] = {
-        QGamepadManager::ButtonGuide,
         QGamepadManager::ButtonR3,
         QGamepadManager::ButtonL3,
+        QGamepadManager::ButtonGuide,
     };
 
     u32 hidPad = 0xfff;

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,4 @@
+#define _USE_MATH_DEFINES
 #include <QWidget>
 #include <QApplication>
 #include <QDebug>
@@ -31,7 +32,7 @@ typedef uint8_t u8;
 double lx = 0.0, ly = 0.0;
 double rx = 0.0, ry = 0.0;
 QGamepadManager::GamepadButtons buttons = 0;
-u32 specialButtons = 0;
+u32 interfaceButtons = 0;
 QString ipAddress;
 int yAxisMultiplier = 1;
 
@@ -60,6 +61,12 @@ void sendFrame(void)
         QGamepadManager::ButtonL2,
     };
 
+    static const QGamepadManager::GamepadButton speButtons[] = {
+        QGamepadManager::ButtonGuide,
+        QGamepadManager::ButtonR3,
+        QGamepadManager::ButtonL3,
+    };
+
     u32 hidPad = 0xfff;
     for(u32 i = 0; i < 12; i++)
     {
@@ -74,14 +81,14 @@ void sendFrame(void)
             irButtonsState |= 1 << (i + 1);
     }
 
-    if (buttons & (1 << QGamepadManager::ButtonGuide))
+    u32 specialButtonsState = 0;
+    for(u32 i = 0; i < 3; i++)
     {
-        specialButtons |= 1;
+
+        if(buttons & (1 << speButtons[i]))
+            specialButtonsState |= 1 << i;
     }
-    else 
-    {
-        specialButtons &= ~1;
-    }
+    specialButtonsState |= interfaceButtons;
 
     u32 touchScreenState = 0x2000000;
     u32 circlePadState = 0x7ff7ff;
@@ -120,7 +127,7 @@ void sendFrame(void)
     qToLittleEndian(touchScreenState, (uchar *)ba.data() + 4);
     qToLittleEndian(circlePadState, (uchar *)ba.data() + 8);
     qToLittleEndian(cppState, (uchar *)ba.data() + 12);
-    qToLittleEndian(specialButtons, (uchar *)ba.data() + 16);
+    qToLittleEndian(specialButtonsState, (uchar *)ba.data() + 16);
     QUdpSocket().writeDatagram(ba, QHostAddress(ipAddress), 4950);
 }
 
@@ -281,42 +288,42 @@ public:
         connect(homeButton, &QPushButton::pressed, this,
                 [](void)
         {
-           specialButtons |= 1;
+           interfaceButtons |= 1;
            sendFrame();
         });
 
         connect(homeButton, &QPushButton::released, this,
                 [](void)
         {
-           specialButtons &= ~1;
+           interfaceButtons &= ~1;
            sendFrame();
         });
 
         connect(powerButton, &QPushButton::pressed, this,
                 [](void)
         {
-           specialButtons |= 2;
+           interfaceButtons |= 2;
            sendFrame();
         });
 
         connect(powerButton, &QPushButton::released, this,
                 [](void)
         {
-           specialButtons &= ~2;
+           interfaceButtons &= ~2;
            sendFrame();
         });
 
         connect(longPowerButton, &QPushButton::pressed, this,
                 [](void)
         {
-           specialButtons |= 4;
+           interfaceButtons |= 4;
            sendFrame();
         });
 
         connect(longPowerButton, &QPushButton::released, this,
                 [](void)
         {
-           specialButtons &= ~4;
+           interfaceButtons &= ~4;
            sendFrame();
         });
 
@@ -340,7 +347,7 @@ public:
     {
         lx = ly = rx = ry = 0.0;
         buttons = 0;
-        specialButtons = 0;
+        interfaceButtons = 0;
         touchScreenPressed = false;
         sendFrame();
         delete touchScreen;


### PR DESCRIPTION
Make the interface buttons always override gamepad buttons if active, also allow accessing the "power" and "power (long)" buttons from the gamepad's joysticks presses (R3 and L3), and also fix compilation with Visual Studio toolchain
fixes #13

Feel free to only take some parts of my changes, as you could find some of them to be incorrect or to not suit your needs.

Actually, I could associate the R3 button to "Home" and the L3 button to "Power", and associate the guide button to "Power (Long)", because it's actually possible that the guide button won't be present on some controllers, and/or that vJoy won't recognize it